### PR TITLE
Check if pm2 exists instead of using which

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -7,7 +7,7 @@
 # Usage         : ./postinstall.sh
 #==============================================================================
 
-if [[ $( which pm2 ) != '/usr/bin/pm2' ]]; then
+if [[ -f '/usr/bin/pm2' ]]; then
 	sudo npm i -g install pm2
 fi
 


### PR DESCRIPTION
This is a better check because the default install script finde pm2 in a
different directory.  See output below, I changed the postinstall script
to debug bash and can see pm2 being picked up from another
location.  Since we simply want to see if pm2 is installed at the
location `/usr/bin/pm2`, simply checking for that file existence is a
better check to see if pm2 is installed globally

```
++ which pm2
+ [[ /home/magicmirror/MagicMirror/modules/MMM-RTSPStream/node_modules/.bin/pm2 != \/\u\s\r\/\b\i\n\/\p\m\2 ]]
+ sudo npm i -g install pm2
```